### PR TITLE
fix: Remove side-effects property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,5 @@
       "@semantic-release/npm"
     ]
   },
-  "sideEffects": false,
   "typings": "typings/index.d.ts"
 }


### PR DESCRIPTION
As it does not have a purpose when there's no imports and only a single default export.