### PR TITLE
fix: no typings directory after publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typecheck": "tsc --noEmit"
   },
   "sideEffects": false,
-  "typings": "dist/index.d.ts",
+  "typings": "typings/index.d.ts",
   "devDependencies": {
     "concurrently": "5.3.0",
     "husky": "4.2.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.module.js",
   "files": [
     "dist",
+    "typings",
     "umd/compute-scroll-into-view.min.js",
     "umd/compute-scroll-into-view.min.js.map"
   ],


### PR DESCRIPTION
@stipsan please consider this pr: typings were lost in files section. Because of that, typings were lost in published package