### PR TITLE
Add support for slotted elements (fixes #916)

### DIFF
--- a/integration/__snapshots__/nested_slots.test.js.snap
+++ b/integration/__snapshots__/nested_slots.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`target in nested slots into scrollable container in shadow DOM block: "nearest" 1`] = `
+[
+  {
+    "el": "div.second-inner-container",
+    "left": 0,
+    "top": 100,
+  },
+  {
+    "el": "div.first-inner-container",
+    "left": 0,
+    "top": 600,
+  },
+  {
+    "el": "html",
+    "left": 0,
+    "top": 0,
+  },
+]
+`;
+
+exports[`target in nested slots into scrollable container in shadow DOM block: "start" 1`] = `
+[
+  {
+    "el": "div.second-inner-container",
+    "left": 0,
+    "top": 600,
+  },
+  {
+    "el": "div.first-inner-container",
+    "left": 0,
+    "top": 600,
+  },
+  {
+    "el": "html",
+    "left": 0,
+    "top": 0,
+  },
+]
+`;

--- a/integration/__snapshots__/slot.test.js.snap
+++ b/integration/__snapshots__/slot.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`target slotted into scrollable container in shadow DOM block: "nearest" 1`] = `
+[
+  {
+    "el": "div.inner-container",
+    "left": 0,
+    "top": 100,
+  },
+  {
+    "el": "html",
+    "left": 0,
+    "top": 0,
+  },
+]
+`;
+
+exports[`target slotted into scrollable container in shadow DOM block: "start" 1`] = `
+[
+  {
+    "el": "div.inner-container",
+    "left": 0,
+    "top": 600,
+  },
+  {
+    "el": "html",
+    "left": 0,
+    "top": 0,
+  },
+]
+`;

--- a/integration/nested_slots.html
+++ b/integration/nested_slots.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta
+  name="viewport"
+  content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+/>
+<script type="module" src="./utils.js"></script>
+<style>
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+    height: 100vh;
+    width: 100vw;
+  }
+  .outer-container {
+    height: 100%;
+    width: 100%;
+    overflow: clip;
+  }
+  .target {
+    background: crimson;
+    height: 100px;
+    width: 100px;
+  }
+</style>
+<div class="outer-container">
+  <template shadowrootmode="open">
+    <style>
+      .outer-container {
+        height: 100%;
+        width: 100%;
+        overflow: clip;
+      }
+      .first-inner-container {
+        height: 100vh;
+        background: whitesmoke;
+        overflow: auto;
+      }
+      .scroller {
+        height: 200vh;
+        width: 90%;
+        padding-top: 100vh;
+        box-sizing: border-box;
+      }
+    </style>
+    <div class="first-inner-container">
+      <div class="scroller">
+        <div class="outer-container">
+          <template shadowrootmode="open">
+            <style>
+              .second-inner-container {
+                height: 100vh;
+                background: whitesmoke;
+                overflow: auto;
+              }
+              .scroller {
+                height: 200vh;
+                width: 90%;
+                padding-top: 100vh;
+                box-sizing: border-box;
+              }
+            </style>
+            <div class="second-inner-container">
+              <div class="scroller">
+                <slot></slot>
+              </div>
+            </div>
+          </template>
+          <slot></slot>
+        </div>
+      </div>
+    </div>
+  </template>
+  <div class="target"></div>
+</div>

--- a/integration/nested_slots.test.js
+++ b/integration/nested_slots.test.js
@@ -1,0 +1,37 @@
+beforeAll(async () => {
+  await page.goto('http://localhost:3000/integration/nested_slots')
+})
+
+describe('target in nested slots into scrollable container in shadow DOM', () => {
+  test('block: "nearest"', async () => {
+    expect.assertions(4)
+    const windowHeight = await page.evaluate(() => window.innerHeight)
+    const actual = await page.evaluate(() => {
+    return window
+      .computeScrollIntoView(document.querySelector('.target'), {
+        block: 'nearest',
+      })
+      .map(window.mapActions)
+    })
+    expect(actual).toHaveLength(3)
+    expect(actual[0]).toMatchObject({ el: 'div.second-inner-container', left: 0, top: 100 })
+    expect(actual[1]).toMatchObject({ el: 'div.first-inner-container', left: 0, top: windowHeight })
+    expect(actual).toMatchSnapshot()
+  })
+
+  test('block: "start"', async () => {
+    expect.assertions(4)
+    const windowHeight = await page.evaluate(() => window.innerHeight)
+    const actual = await page.evaluate(() => {
+      return window
+      .computeScrollIntoView(document.querySelector('.target'), {
+        block: 'start',
+      })
+      .map(window.mapActions)
+    })
+    expect(actual).toHaveLength(3)
+    expect(actual[0]).toMatchObject({ el: 'div.second-inner-container', left: 0, top: windowHeight })
+    expect(actual[1]).toMatchObject({ el: 'div.first-inner-container', left: 0, top: windowHeight })
+    expect(actual).toMatchSnapshot()
+  })
+})

--- a/integration/slot.html
+++ b/integration/slot.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta
+  name="viewport"
+  content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+/>
+<script type="module" src="./utils.js"></script>
+<style>
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+    height: 100vh;
+    width: 100vw;
+  }
+  .outer-container {
+    height: 100vh;
+    width: 100vw;
+    overflow: clip;
+  }
+  .target {
+    background: crimson;
+    height: 100px;
+    width: 100px;
+  }
+</style>
+<div class="outer-container">
+  <template shadowrootmode="open">
+    <style>
+      .inner-container {
+        height: 100vh;
+        background: whitesmoke;
+        overflow: auto;
+      }
+
+      .scroller {
+        height: 200vh;
+        padding-top: 100vh;
+        box-sizing: border-box;
+      }
+    </style>
+    <div class="inner-container">
+      <div class="scroller">
+        <slot></slot>
+      </div>
+    </div>
+  </template>
+  <div class="target"></div>
+</div>

--- a/integration/slot.test.js
+++ b/integration/slot.test.js
@@ -1,0 +1,34 @@
+beforeAll(async () => {
+  await page.goto('http://localhost:3000/integration/slot')
+})
+
+describe('target slotted into scrollable container in shadow DOM', () => {
+  test('block: "nearest"', async () => {
+    expect.assertions(3)
+    const actual = await page.evaluate(() => {
+    return window
+      .computeScrollIntoView(document.querySelector('.target'), {
+        block: 'nearest',
+      })
+      .map(window.mapActions)
+    })
+    expect(actual).toHaveLength(2)
+    expect(actual[0]).toMatchObject({ el: 'div.inner-container', left: 0, top: 100 })
+    expect(actual).toMatchSnapshot()
+  })
+
+  test('block: "start"', async () => {
+    expect.assertions(3)
+    const windowHeight = await page.evaluate(() => window.innerHeight);
+    const actual = await page.evaluate(() => {
+      return window
+      .computeScrollIntoView(document.querySelector('.target'), {
+        block: 'start',
+      })
+      .map(window.mapActions)
+    })
+    expect(actual).toHaveLength(2)
+    expect(actual[0]).toMatchObject({ el: 'div.inner-container', left: 0, top: windowHeight })
+    expect(actual).toMatchSnapshot()
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,7 +267,9 @@ const alignNearest = (
 }
 
 const getParentElement = (element: Node): Element | null => {
-  const parent = element.parentElement
+  const parent = isElement(element)
+    ? (element.assignedSlot ?? element.parentElement)
+    : element.parentElement
   if (parent == null) {
     return (element.getRootNode() as ShadowRoot).host || null
   }


### PR DESCRIPTION
If the target is slotted into a shadow DOM, then it may have scrollable ancestors in that shadow DOM.

By using the assigned slot instead of the parent element (if it has one), we can properly scroll the slot's ancestors before going up through the shadow root's ancestors.

This simple change seems to be enough to fix #916 